### PR TITLE
Updated to Spring 3.1.2.RELEASE. Reverted two Findbugs fixes to UITypes ...

### DIFF
--- a/maven.xml
+++ b/maven.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project default="full"  >
+
+	<goal name="full">
+		<attainGoal name="jar:install" />
+	</goal>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -28,11 +28,13 @@
   <version>0.8.0-SNAPSHOT</version>
 
   <repositories>
+    <!--
     <repository>
       <id>CARET-Maven2</id>
       <name>CARET Maven 2 Repository</name>
       <url>http://www2.caret.cam.ac.uk/maven2</url>
     </repository>
+    -->
   </repositories>
   
   <scm>
@@ -157,7 +159,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
-      <version>2.5.6.SEC03</version>
+      <version>3.1.2.RELEASE</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>

--- a/project.properties
+++ b/project.properties
@@ -1,0 +1,9 @@
+maven.javadoc.debug = true
+maven.javadoc.mode.online = true
+maven.javadoc.links=http://java.sun.com/j2se/1.4.2/docs/api/, http://saffron.caret.cam.ac.uk/projects/PonderUtilCore/apidocs/, http://saffron.caret.cam.ac.uk/projects/ServletUtil/apidocs/, http://java.sun.com/j2ee/sdk_1.3/techdocs/api/
+maven.javadoc.offlineLinks=file:///e:/workspace/PonderUtilCore/target/docs/apidocs
+maven.javadoc.additionalparam=-breakiterator
+rsfutil.version=0.7.6-SNAPSHOT
+ponderutilcore.version=1.2.6-SNAPSHOT
+jservletutil.version=1.2.6-SNAPSHOT
+maven.repo.remote=http://repo1.maven.org/maven/

--- a/project.xml
+++ b/project.xml
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <pomVersion>3</pomVersion>
+  <artifactId>rsfutil</artifactId>
+  <name>J-RSFUtil</name>
+  <groupId>rsfutil</groupId>
+  <currentVersion>${rsfutil.version}</currentVersion>
+  <organization>
+    <name>CARET, University of Cambridge</name>
+    <url>http://www.caret.cam.ac.uk/</url>
+  </organization>
+  <inceptionYear>2005</inceptionYear>
+  <properties>
+    <deploy.type>jar</deploy.type>
+  </properties>
+  <logo>/images/logo.gif</logo>
+  <shortDescription>
+    RSFUtil implements the RSF web framework
+  </shortDescription>
+  <description>RSFUtil provides the rsfutil.jar package.</description>
+  <developers>
+    <developer>
+      <id>amb26</id>
+      <name>Antranig Basman</name>
+      <email>antranig@caret.cam.ac.uk</email>
+      <url>http://www.caret.cam.ac.uk/contact/people/index.html</url>
+      <organization>CARET</organization>
+      <organizationUrl>http://www.caret.cam.ac.uk/</organizationUrl>
+      <roles>
+        <role>Developer</role>
+        <role>Project Manager</role>
+      </roles>
+      <timezone>0</timezone>
+      <properties />
+    </developer>
+    <developer>
+      <id>andrew</id>
+      <name>Andrew Thornton</name>
+      <email>andrew@caret.cam.ac.uk</email>
+      <url>http://www.caret.cam.ac.uk/contact/people/index.html</url>
+      <organization>CARET</organization>
+      <organizationUrl>http://www.caret.cam.ac.uk/</organizationUrl>
+      <roles>
+        <role>Developer</role>
+      </roles>
+      <timezone>0</timezone>
+      <properties />
+    </developer>
+  </developers>
+  <licenses>
+    <license>
+      <name>CARET Open Source licence</name>
+      <url>
+        http://saffron.caret.cam.ac.uk/cgi-bin/cvsweb/rep/FlowTalkServlet/licence.txt?rev=1.1;content-type=text%2Fplain
+      </url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <mailingLists>
+    <mailingList>
+      <name>${pom.name} Dev List</name>
+    </mailingList>
+    <mailingList>
+      <name>${pom.name} User List</name>
+    </mailingList>
+  </mailingLists>
+  <gumpRepositoryId>caret-saffron-svn</gumpRepositoryId>
+  <siteAddress>saffron.caret.cam.ac.uk</siteAddress>
+  <siteDirectory>/home/gump/project-websites/RSFUtil/</siteDirectory>
+  <distributionSite>saffron.caret.cam.ac.uk</distributionSite>
+  <distributionDirectory>
+    /home/gump/project-downloads/RSFUtil
+  </distributionDirectory>
+  <repository>
+    <connection>
+      scm:svn:https://saffron.caret.cam.ac.uk/svn/projects/RSFUtil/trunk
+    </connection>
+    <developerConnection>
+      scm:svn:https://saffron.caret.cam.ac.uk/svn/projects/RSFUtil/trunk
+    </developerConnection>
+    <url>https://saffron.caret.cam.ac.uk/cgi-bin/viewcvs.cgi/</url>
+  </repository>
+
+  <reports>
+    <report>maven-jdepend-plugin</report>
+    <report>maven-changelog-plugin</report>
+    <report>maven-changes-plugin</report>
+    <report>maven-checkstyle-plugin</report>
+    <report>maven-dashboard-plugin</report>
+    <report>maven-developer-activity-plugin</report>
+    <report>maven-file-activity-plugin</report>
+    <report>maven-javadoc-plugin</report>
+    <report>maven-license-plugin</report>
+    <report>maven-linkcheck-plugin</report>
+    <report>maven-faq-plugin</report>
+    <report>maven-multiproject-plugin</report>
+    <report>maven-multichanges-plugin</report>
+    <report>maven-tasklist-plugin</report>
+  </reports>
+  <dependencies>
+    <dependency>
+      <groupId>ponderutilcore</groupId>
+      <artifactId>ponderutilcore</artifactId>
+      <version>${ponderutilcore.version}</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>j-servletutil</groupId>
+      <artifactId>j-servletutil</artifactId>
+      <version>${jservletutil.version}</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>servletapi</groupId>
+      <artifactId>servletapi</artifactId>
+      <version>2.3</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>1.2.9</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring</artifactId>
+      <version>1.2.8</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-mock</artifactId>
+      <version>1.2.6</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>xpp3</groupId>
+      <artifactId>xpp3_min</artifactId>
+      <version>1.1.3.4-RC8</version>
+      <type>jar</type>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>src</sourceDirectory>
+    <resources>
+      <!-- include the readme.txt file and the java source files -->
+      <resource>
+        <directory>${basedir}</directory>
+        <includes>
+          <include>*.txt</include>
+          <include>src/**/*.java</include>
+          <include>src/**/*.html</include>
+          <include>src/**/*.xml</include>
+          <include>src/**/*.properties</include>
+        </includes>
+      </resource>
+      <resource>
+        <directory>src/</directory>
+        <targetPath>/</targetPath>
+        <includes>
+          <include>**/*.xml</include>
+        </includes>
+        <includes>
+          <include>**/*.html</include>
+        </includes>
+        <includes>
+          <include>**/*.dtd</include>
+        </includes>
+        <filtering>false</filtering>
+      </resource>
+    </resources>
+  </build>
+</project>
+

--- a/src/conf/blank-applicationContext.xml
+++ b/src/conf/blank-applicationContext.xml
@@ -18,7 +18,17 @@
     <property name="parentMessageSource" ref="builtinMessageSource"/>
   </bean> 
 
-  <bean id="builtinMessageSource" class="org.springframework.context.support.ResourceBundleMessageSource">
+  <!-- This applies an unusual hack in order to function correctly with Spring 3.x.
+   With this version, the implementation of "application listeners" has altered, and the 
+   "application listener turns loader" strategy that we used in order to load TLABPostProcessorLoader
+   no longer works - the new Spring 3.x strategy does not actually LOAD THE CONCRETE BEAN until the
+   first application event actually arrives, which unfortunately is "onRefresh", far too late in the cycle.
+   However, this RSF framework standard bean is unavoidable in every configuration, and being a messageSource
+   is loaded by Spring at the right point in its lifecycle (see implementation in Spring's
+   AbstractApplicationContext.java -->
+
+  <bean id="builtinMessageSource" class="org.springframework.context.support.ResourceBundleMessageSource" 
+        depends-on="TLABPostProcessorLoader">
     <property name="basename" value="uk/org/ponder/rsf/builtin/messages/messages"/>
   </bean>
 

--- a/src/uk/org/ponder/rsf/uitype/BooleanUIType.java
+++ b/src/uk/org/ponder/rsf/uitype/BooleanUIType.java
@@ -5,7 +5,8 @@ package uk.org.ponder.rsf.uitype;
 
 public class BooleanUIType implements UIType {
   public static final BooleanUIType instance = new BooleanUIType();
-  public Boolean PLACEHOLDER = Boolean.FALSE;
+  // This value is compared by reference equality in UITypes.java - this is not a bad constant (Findbugs)
+  public Boolean PLACEHOLDER = new Boolean(false);
 
   public Object getPlaceholder() {
     return PLACEHOLDER;

--- a/src/uk/org/ponder/rsf/uitype/StringUIType.java
+++ b/src/uk/org/ponder/rsf/uitype/StringUIType.java
@@ -5,7 +5,8 @@ package uk.org.ponder.rsf.uitype;
 
 public class StringUIType implements UIType {
   public static final StringUIType instance = new StringUIType();
-  public String PLACEHOLDER = "";
+  // This value is compared by reference equality in UITypes.java - this is not a bad constant (Findbugs)
+  public String PLACEHOLDER = new String("");
 
   public Object getPlaceholder() {
     return PLACEHOLDER;


### PR DESCRIPTION
...which were not bugs (generation of boolean and String constants). Recovered Maven 1.x build files for use with Javadocs. New Spring 3.x strategy converts "application listener turns loader" into "message source turns loader" as a result of change in Spring listener resolution strategy. This should be portable across all Spring versions
